### PR TITLE
Commands no longer requires --groups-exclude-suffix to get all the groups

### DIFF
--- a/cmd/gke-identity-service-migrator/main.go
+++ b/cmd/gke-identity-service-migrator/main.go
@@ -533,7 +533,7 @@ func (r *subjectRecognizer) GetFederatedGroup(sub rbacv1.Subject) (string, bool)
 	if !strings.HasPrefix(sub.Name, r.groupsIncludePrefix) {
 		return "", false
 	}
-	if strings.HasSuffix(sub.Name, r.groupsExcludeSuffix) {
+	if r.groupsExcludeSuffix != "" && strings.HasSuffix(sub.Name, r.groupsExcludeSuffix) {
 		return "", false
 	}
 	return strings.TrimPrefix(sub.Name, r.groupsIncludePrefix), true


### PR DESCRIPTION
This PR is related to the issue #6 (https://github.com/GoogleCloudPlatform/gke-utilities/issues/6).

find-rolebindings and related commands don't require anymore to set --groups-exclude-suffix when no exclusion is desired in order to get all the groups.